### PR TITLE
bug fix : jnp.split

### DIFF
--- a/model.py
+++ b/model.py
@@ -53,7 +53,7 @@ class CausalSelfAttention(nn.Module):
         B, T, C = x.shape # batch size, sequence length, embedding dimensionality (n_embd)
 
         # calculate query, key, values for all heads in batch and move head forward to be the batch dim
-        q, k ,v  = self.c_attn(x).split(3, axis=-1)
+        q,k,v=jnp.split(self.c_attn(x),3,axis=-1)
         q = q.reshape(B, T, self.n_head, C // self.n_head).swapaxes(1, 2) # (B, nh, T, hs)
         k = k.reshape(B, T, self.n_head, C // self.n_head).swapaxes(1, 2) # (B, nh, T, hs)
         v = v.reshape(B, T, self.n_head, C // self.n_head).swapaxes(1, 2) # (B, nh, T, hs)


### PR DESCRIPTION
Updated from array.split(args) [invalid call] to jax.numpy.split(array,args) [valid calls]